### PR TITLE
Contracts: remove unnecessary upper bound on amounts

### DIFF
--- a/dist/michelson/finp2p_proxy.json
+++ b/dist/michelson/finp2p_proxy.json
@@ -1854,67 +1854,56 @@
                 [ { "prim": "UNPAIR" }, { "prim": "UNPAIR" },
                   { "prim": "DIG", "args": [ { "int": "2" } ] },
                   { "prim": "PUSH",
-                    "args":
-                      [ { "prim": "nat" }, { "int": "9223372036854775807" } ] },
+                    "args": [ { "prim": "nat" }, { "int": "0" } ] },
                   { "prim": "SWAP" }, { "prim": "DUP" },
                   { "prim": "DUG", "args": [ { "int": "2" } ] },
-                  { "prim": "COMPARE" }, { "prim": "GT" },
+                  { "prim": "COMPARE" }, { "prim": "EQ" },
                   { "prim": "IF",
                     "args":
                       [ [ { "prim": "DIG", "args": [ { "int": "2" } ] },
                           { "prim": "DROP", "args": [ { "int": "2" } ] },
                           { "prim": "PUSH",
                             "args":
-                              [ { "prim": "string" },
-                                { "string": "BAD_INT64_NAT" } ] },
-                          { "prim": "FAILWITH" } ],
+                              [ { "prim": "string" }, { "string": "0x0" } ] } ],
                         [ { "prim": "PUSH",
-                            "args": [ { "prim": "nat" }, { "int": "0" } ] },
-                          { "prim": "SWAP" }, { "prim": "DUP" },
-                          { "prim": "DUG", "args": [ { "int": "2" } ] },
-                          { "prim": "COMPARE" }, { "prim": "EQ" },
-                          { "prim": "IF",
                             "args":
-                              [ [ { "prim": "DIG",
-                                    "args": [ { "int": "2" } ] },
-                                  { "prim": "DROP",
-                                    "args": [ { "int": "2" } ] },
+                              [ { "prim": "string" }, { "string": "" } ] },
+                          { "prim": "SWAP" }, { "prim": "PAIR" },
+                          { "prim": "LEFT",
+                            "args": [ { "prim": "string" } ] },
+                          { "prim": "LOOP_LEFT",
+                            "args":
+                              [ [ { "prim": "UNPAIR" },
                                   { "prim": "PUSH",
                                     "args":
-                                      [ { "prim": "string" },
-                                        { "string": "0x0" } ] } ],
-                                [ { "prim": "NIL",
-                                    "args": [ { "prim": "string" } ] },
-                                  { "prim": "PUSH",
-                                    "args":
-                                      [ { "prim": "nat" }, { "int": "15" } ] },
-                                  { "prim": "DIG",
+                                      [ { "prim": "nat" }, { "int": "0" } ] },
+                                  { "prim": "SWAP" }, { "prim": "DUP" },
+                                  { "prim": "DUG",
                                     "args": [ { "int": "2" } ] },
-                                  { "prim": "PAIR" }, { "prim": "PAIR" },
-                                  { "prim": "LEFT",
-                                    "args": [ { "prim": "string" } ] },
-                                  { "prim": "LOOP_LEFT",
+                                  { "prim": "COMPARE" }, { "prim": "EQ" },
+                                  { "prim": "IF",
                                     "args":
-                                      [ [ { "prim": "UNPAIR" },
-                                          { "prim": "UNPAIR" },
+                                      [ [ { "prim": "DROP" },
+                                          { "prim": "PUSH",
+                                            "args":
+                                              [ { "prim": "string" },
+                                                { "string": "0x" } ] },
+                                          { "prim": "CONCAT" },
+                                          { "prim": "RIGHT",
+                                            "args":
+                                              [ { "prim": "pair",
+                                                  "args":
+                                                    [ { "prim": "nat" },
+                                                      { "prim": "string" } ] } ] } ],
+                                        [ { "prim": "DUP",
+                                            "args": [ { "int": "4" } ] },
                                           { "prim": "PUSH",
                                             "args":
                                               [ { "prim": "nat" },
                                                 { "int": "15" } ] },
-                                          { "prim": "PUSH",
-                                            "args":
-                                              [ { "prim": "nat" },
-                                                { "int": "4" } ] },
-                                          { "prim": "DUP",
-                                            "args": [ { "int": "4" } ] },
-                                          { "prim": "MUL" },
                                           { "prim": "DUP",
                                             "args": [ { "int": "3" } ] },
-                                          { "prim": "LSR" },
                                           { "prim": "AND" },
-                                          { "prim": "DUP",
-                                            "args": [ { "int": "6" } ] },
-                                          { "prim": "SWAP" },
                                           { "prim": "GET" },
                                           { "prim": "IF_NONE",
                                             "args":
@@ -1926,92 +1915,21 @@
                                                 [] ] },
                                           { "prim": "PUSH",
                                             "args":
-                                              [ { "prim": "string" },
-                                                { "string": "0" } ] },
-                                          { "prim": "SWAP" },
-                                          { "prim": "DUP" },
+                                              [ { "prim": "nat" },
+                                                { "int": "4" } ] },
+                                          { "prim": "DIG",
+                                            "args": [ { "int": "2" } ] },
+                                          { "prim": "LSR" },
                                           { "prim": "DUG",
                                             "args": [ { "int": "2" } ] },
-                                          { "prim": "COMPARE" },
-                                          { "prim": "EQ" },
-                                          { "prim": "IF",
-                                            "args":
-                                              [ [ { "prim": "DUP",
-                                                    "args":
-                                                      [ { "int": "4" } ] },
-                                                  { "prim": "IF_CONS",
-                                                    "args":
-                                                      [ [ { "prim": "DROP",
-                                                            "args":
-                                                              [ { "int": "2" } ] },
-                                                          { "prim": "DIG",
-                                                            "args":
-                                                              [ { "int": "3" } ] },
-                                                          { "prim": "SWAP" },
-                                                          { "prim": "CONS" } ],
-                                                        [ { "prim": "DROP" },
-                                                          { "prim": "DIG",
-                                                            "args":
-                                                              [ { "int": "2" } ] } ] ] } ],
-                                                [ { "prim": "DIG",
-                                                    "args":
-                                                      [ { "int": "3" } ] },
-                                                  { "prim": "SWAP" },
-                                                  { "prim": "CONS" } ] ] },
-                                          { "prim": "PUSH",
-                                            "args":
-                                              [ { "prim": "nat" },
-                                                { "int": "1" } ] },
-                                          { "prim": "DIG",
-                                            "args": [ { "int": "3" } ] },
-                                          { "prim": "SUB" },
-                                          { "prim": "ISNAT" },
-                                          { "prim": "IF_NONE",
-                                            "args":
-                                              [ [ { "prim": "SWAP" },
-                                                  { "prim": "DROP" },
-                                                  { "prim": "NIL",
-                                                    "args":
-                                                      [ { "prim": "string" } ] },
-                                                  { "prim": "SWAP" },
-                                                  { "prim": "ITER",
-                                                    "args":
-                                                      [ [ { "prim": "CONS" } ] ] },
-                                                  { "prim": "PUSH",
-                                                    "args":
-                                                      [ { "prim": "string" },
-                                                        { "string": "0x" } ] },
-                                                  { "prim": "CONS" },
-                                                  { "prim": "CONCAT" },
-                                                  { "prim": "RIGHT",
-                                                    "args":
-                                                      [ { "prim": "pair",
-                                                          "args":
-                                                            [ { "prim":
-                                                                  "pair",
-                                                                "args":
-                                                                  [ { "prim":
-                                                                    "nat" },
-                                                                    { "prim":
-                                                                    "nat" } ] },
-                                                              { "prim":
-                                                                  "list",
-                                                                "args":
-                                                                  [ { "prim":
-                                                                    "string" } ] } ] } ] } ],
-                                                [ { "prim": "DIG",
-                                                    "args":
-                                                      [ { "int": "2" } ] },
-                                                  { "prim": "PAIR" },
-                                                  { "prim": "PAIR" },
-                                                  { "prim": "LEFT",
-                                                    "args":
-                                                      [ { "prim": "string" } ] } ] ] } ] ] },
-                                  { "prim": "DIG",
-                                    "args": [ { "int": "2" } ] },
-                                  { "prim": "DROP" } ] ] } ] ] },
-                  { "prim": "EXEC" } ] ] }, { "prim": "SWAP" },
-          { "prim": "APPLY" },
+                                          { "prim": "CONCAT" },
+                                          { "prim": "SWAP" },
+                                          { "prim": "PAIR" },
+                                          { "prim": "LEFT",
+                                            "args": [ { "prim": "string" } ] } ] ] } ] ] },
+                          { "prim": "DIG", "args": [ { "int": "2" } ] },
+                          { "prim": "DROP" } ] ] }, { "prim": "EXEC" } ] ] },
+          { "prim": "SWAP" }, { "prim": "APPLY" },
           { "prim": "LAMBDA",
             "args":
               [ { "prim": "pair",

--- a/dist/michelson/finp2p_proxy.tz
+++ b/dist/michelson/finp2p_proxy.tz
@@ -830,65 +830,42 @@
            { UNPAIR ;
              UNPAIR ;
              DIG 2 ;
-             PUSH nat 9223372036854775807 ;
+             PUSH nat 0 ;
              SWAP ;
              DUP ;
              DUG 2 ;
              COMPARE ;
-             GT ;
-             IF { DIG 2 ; DROP 2 ; PUSH string "BAD_INT64_NAT" ; FAILWITH }
-                { PUSH nat 0 ;
+             EQ ;
+             IF { DIG 2 ; DROP 2 ; PUSH string "0x0" }
+                { PUSH string "" ;
                   SWAP ;
-                  DUP ;
-                  DUG 2 ;
-                  COMPARE ;
-                  EQ ;
-                  IF { DIG 2 ; DROP 2 ; PUSH string "0x0" }
-                     { NIL string ;
-                       PUSH nat 15 ;
-                       DIG 2 ;
-                       PAIR ;
-                       PAIR ;
-                       LEFT string ;
-                       LOOP_LEFT
-                         { UNPAIR ;
-                           UNPAIR ;
+                  PAIR ;
+                  LEFT string ;
+                  LOOP_LEFT
+                    { UNPAIR ;
+                      PUSH nat 0 ;
+                      SWAP ;
+                      DUP ;
+                      DUG 2 ;
+                      COMPARE ;
+                      EQ ;
+                      IF { DROP ; PUSH string "0x" ; CONCAT ; RIGHT (pair nat string) }
+                         { DUP 4 ;
                            PUSH nat 15 ;
-                           PUSH nat 4 ;
-                           DUP 4 ;
-                           MUL ;
                            DUP 3 ;
-                           LSR ;
                            AND ;
-                           DUP 6 ;
-                           SWAP ;
                            GET ;
                            IF_NONE { PUSH string "" ; FAILWITH } {} ;
-                           PUSH string "0" ;
-                           SWAP ;
-                           DUP ;
+                           PUSH nat 4 ;
+                           DIG 2 ;
+                           LSR ;
                            DUG 2 ;
-                           COMPARE ;
-                           EQ ;
-                           IF { DUP 4 ; IF_CONS { DROP 2 ; DIG 3 ; SWAP ; CONS } { DROP ; DIG 2 } }
-                              { DIG 3 ; SWAP ; CONS } ;
-                           PUSH nat 1 ;
-                           DIG 3 ;
-                           SUB ;
-                           ISNAT ;
-                           IF_NONE
-                             { SWAP ;
-                               DROP ;
-                               NIL string ;
-                               SWAP ;
-                               ITER { CONS } ;
-                               PUSH string "0x" ;
-                               CONS ;
-                               CONCAT ;
-                               RIGHT (pair (pair nat nat) (list string)) }
-                             { DIG 2 ; PAIR ; PAIR ; LEFT string } } ;
-                       DIG 2 ;
-                       DROP } } ;
+                           CONCAT ;
+                           SWAP ;
+                           PAIR ;
+                           LEFT string } } ;
+                  DIG 2 ;
+                  DROP } ;
              EXEC } ;
          SWAP ;
          APPLY ;

--- a/tezos-lib/finp2p_proxy.ts
+++ b/tezos-lib/finp2p_proxy.ts
@@ -14,6 +14,7 @@ import { HttpBackend } from '@taquito/http-utils';
 import { b58cdecode, prefix } from '@taquito/utils';
 import { ParameterSchema } from '@taquito/michelson-encoder';
 const PromiseAny = require('promise-any');
+import { BigNumber } from 'bignumber.js';
 
 import * as finp2pProxyCode from '../dist/michelson/finp2p_proxy.json';
 import * as fa2Code from '../dist/michelson/fa2.json';
@@ -563,23 +564,23 @@ export class FinP2PTezos {
     if (!metadata.hasOwnProperty('permissions')) {
       (metadata as any).permissions =
         {
-          operator: "owner-or-operator",
-          receiver: "owner-no-hook",
-          sender: "owner-no-hook",
+          operator: 'owner-or-operator',
+          receiver: 'owner-no-hook',
+          sender: 'owner-no-hook',
           custom: {
-            tag: "finp2p2_authorization",
-            'config-api': auth_contract }
-        }
+            tag: 'finp2p2_authorization',
+            'config-api': auth_contract },
+        };
     }
     if (!metadata.hasOwnProperty('interfaces')) {
-      (metadata as any).interfaces = [ 'TZIP-012' ]
+      (metadata as any).interfaces = [ 'TZIP-012' ];
     }
     if (!metadata.hasOwnProperty('version')) {
-      (metadata as any).version = "0.1"
+      (metadata as any).version = '0.1';
     }
     let michMetadata = new MichelsonMap<string, Bytes>();
     Object.entries(metadata).forEach(
-      ([k, v]) => michMetadata.set(k, utf8.encode(toStr(v)))
+      ([k, v]) => michMetadata.set(k, utf8.encode(toStr(v))),
     );
     let initialStorage = {
       auth_contract,
@@ -1066,7 +1067,7 @@ export class FinP2PTezos {
   async getAssetBalance(
     publicKey : Key,
     assetId : AssetId,
-    kt1?: Address) : Promise<BigInt> {
+    kt1?: Address) : Promise<bigint> {
     let addr = this.getProxyAddress(kt1);
     const contract = await this.taquito.contract.at(addr);
     let pk = publicKey;
@@ -1077,8 +1078,8 @@ export class FinP2PTezos {
       let balance =
         await contract.contractViews.get_asset_balance(
           [pk, assetId],
-        ).executeView({ viewCaller : addr }) as bigint | undefined;
-      return (balance || BigInt(0));
+        ).executeView({ viewCaller : addr }) as BigNumber | undefined;
+      return (BigInt((balance || new BigNumber(0)).toString()));
     } catch (e : any) {
       const matches = e.message.match(/.*failed with: {\"string\":\"(\w+)\"}/);
       if (matches) {

--- a/tezos-lib/package-lock.json
+++ b/tezos-lib/package-lock.json
@@ -15,6 +15,7 @@
         "@taquito/signer": "^11.1.0",
         "@taquito/taquito": "^11.1.0",
         "@taquito/utils": "^11.1.0",
+        "bignumber.js": "^9.0.2",
         "hacl-wasm": "^1.1.0",
         "promise-any": "^0.2.0",
         "xhr2": "^0.2.1",

--- a/tezos-lib/package.json
+++ b/tezos-lib/package.json
@@ -10,6 +10,7 @@
     "@taquito/signer": "^11.1.0",
     "@taquito/taquito": "^11.1.0",
     "@taquito/utils": "^11.1.0",
+    "bignumber.js": "^9.0.2",
     "hacl-wasm": "^1.1.0",
     "promise-any": "^0.2.0",
     "xhr2": "^0.2.1",


### PR DESCRIPTION
Amounts are unbounded.  
This was a remnant of when amounts were expected to be signed on their padded int64 big endian encoding.