### PR TITLE
Update to Ithaca testnet + redeploy scripts

### DIFF
--- a/.github/workflows/test-ts-lib.yml
+++ b/.github/workflows/test-ts-lib.yml
@@ -32,13 +32,14 @@ jobs:
 
     - name: Install dev dependencies
       run: make ts-dev-deps server-dev-deps
-      
-    - name: Test on Hangzhou
-      run: make test
-      env:
-        FINP2P_SANDBOX_NETWORK: hangzhou
 
     - name: Test on Ithaca
       run: make test
       env:
         FINP2P_SANDBOX_NETWORK: ithaca
+
+    ## Uncomment when jakarta lands in flextesa
+    # - name: Test on Jakarta
+    #   run: make test
+    #   env:
+    #     FINP2P_SANDBOX_NETWORK: jakarta

--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,6 @@ start-sandbox-network:
 
 stop-sandbox-network:
 	@npx --prefix tezos-lib ts-node tezos-lib/tests/sandbox.ts stop
+
+redeploy-contracts:
+	@npx --prefix tezos-lib ts-node tezos-lib/tests/redeploy_contracts.ts configs/testnet-config.json

--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ stop-sandbox-network:
 	@npx --prefix tezos-lib ts-node tezos-lib/tests/sandbox.ts stop
 
 redeploy-contracts:
-	@npx --prefix tezos-lib ts-node tezos-lib/tests/redeploy_contracts.ts configs/testnet-config.json
+	@scripts/redeploy.sh

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ the following addresses:
 
 Contract | Address
 ---|---
-FinP2P Proxy | [KT1QfEsETrSaKvJTmrqFdLYAgRgq6Hw4hM8W](https://better-call.dev/hangzhou2net/KT1QfEsETrSaKvJTmrqFdLYAgRgq6Hw4hM8W)
-FinP2P FA2 | [KT1L2TH91yZ5hGquq28vud2N1eipQKRwiUqA](https://better-call.dev/hangzhou2net/KT1L2TH91yZ5hGquq28vud2N1eipQKRwiUqA)
-Authorization contract | [KT1B8ZhxLP6w6B2R5DtUs1KJbp6Gi9qn5Tyw](https://better-call.dev/hangzhou2net/KT1B8ZhxLP6w6B2R5DtUs1KJbp6Gi9qn5Tyw)
+FinP2P Proxy | [KT1XdwJGUSMuVxRnZaqw2CQjs7ZSP1md4Zn7](https://better-call.dev/hangzhou2net/KT1XdwJGUSMuVxRnZaqw2CQjs7ZSP1md4Zn7)
+FinP2P FA2 | [KT1L6ECRXS6j2gD4owz2eQAgC1tHdsU52qn4](https://better-call.dev/hangzhou2net/KT1L6ECRXS6j2gD4owz2eQAgC1tHdsU52qn4)
+Authorization contract | [KT1QrFjiATDrTRAj6Y17K815GPDFWzhrGpjf](https://better-call.dev/hangzhou2net/KT1QrFjiATDrTRAj6Y17K815GPDFWzhrGpjf)
 
 The provided links to the BetterCallDev explorer allows to see the different
 operations and the tokens on the FA2 contract.

--- a/configs/testnet-config.json
+++ b/configs/testnet-config.json
@@ -1,0 +1,25 @@
+{
+  "url": "https://rpc.ithacanet.teztnets.xyz",
+  "blockTime": 15,
+  "account": {
+    "pkh": "tz1RwdbEstzX1hyes44tRE1i37YcoNMriEaB",
+    "pk": "edpkumnf9MeqsHEcdYuH3JATfmi6sqMm2re2gRDyC2cejZYkr3SHxP",
+    "sk": "edsk2zTy1q1FQoLwMWxtUkmRfqijJu7sYSxaXj89P8X5fq55nPPFf7"
+  },
+  "admins": [
+    "tz1RwdbEstzX1hyes44tRE1i37YcoNMriEaB"
+  ],
+  "explorers": [
+    {
+      "kind": "TzKT",
+      "url": "https://api.ithacanet.tzkt.io"
+    },
+    {
+      "kind": "tzstats",
+      "url": "https://api.ithaca.tzstats.com"
+    }
+  ],
+  "finp2pAuthAddress": "KT1B8ZhxLP6w6B2R5DtUs1KJbp6Gi9qn5Tyw",
+  "finp2pFA2Address": "KT1L2TH91yZ5hGquq28vud2N1eipQKRwiUqA",
+  "finp2pProxyAddress": "KT1QfEsETrSaKvJTmrqFdLYAgRgq6Hw4hM8W"
+}

--- a/configs/testnet-config.json
+++ b/configs/testnet-config.json
@@ -19,7 +19,7 @@
       "url": "https://api.ithaca.tzstats.com"
     }
   ],
-  "finp2pAuthAddress": "KT1B8ZhxLP6w6B2R5DtUs1KJbp6Gi9qn5Tyw",
-  "finp2pFA2Address": "KT1L2TH91yZ5hGquq28vud2N1eipQKRwiUqA",
-  "finp2pProxyAddress": "KT1QfEsETrSaKvJTmrqFdLYAgRgq6Hw4hM8W"
+  "finp2pAuthAddress": "KT1QrFjiATDrTRAj6Y17K815GPDFWzhrGpjf",
+  "finp2pFA2Address": "KT1L6ECRXS6j2gD4owz2eQAgC1tHdsU52qn4",
+  "finp2pProxyAddress": "KT1XdwJGUSMuVxRnZaqw2CQjs7ZSP1md4Zn7"
 }

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_dir="$(cd "$(dirname "$0")" && echo "$(pwd -P)/")"
+dir="$(dirname "$script_dir")"
+
+cd "$dir"
+
+# Use this to replace in all files, maybe too violent
+# files=$(find "$dir" -type f)
+
+files="README.md server/src/helpers/config.ts"
+
+cp configs/testnet-config.json /tmp/tmp-config.json
+npx --prefix tezos-lib ts-node tezos-lib/tests/redeploy_contracts.ts /tmp/tmp-config.json
+
+fields=("finp2pAuthAddress" "finp2pFA2Address" "finp2pProxyAddress")
+replacements=""
+for field in "${fields[@]}"; do
+    old="$(cat configs/testnet-config.json | jq -r .$field)"
+    new="$(cat /tmp/tmp-config.json | jq -r .$field)"
+    replacements="$replacements;s/$old/$new/g"
+done
+
+sedi=(-i)
+case "$(uname)" in
+  # For macOS, use two parameters
+  Darwin*) sedi=(-i "")
+esac
+
+for f in $files; do
+    sed "${sedi[@]}" -e "$replacements" $f
+done
+
+cp /tmp/tmp-config.json configs/testnet-config.json

--- a/server/src/helpers/config.ts
+++ b/server/src/helpers/config.ts
@@ -190,7 +190,7 @@ export let accounts = (process.env.USE_FLEXTESA == 'true') ? Flextesa.accounts :
 // Initialize FinP2P library
 //TODO: move this to configuration
 export const contracts = {
-  finp2pAuthAddress : process.env.FINP2P_AUTH_ADDRESS || 'KT19FphHNf55Y5LkEQwXtBw9w2zJsiHNduj2',
+  finp2pAuthAddress : process.env.FINP2P_AUTH_ADDRESS || 'KT1B8ZhxLP6w6B2R5DtUs1KJbp6Gi9qn5Tyw',
   finp2pFA2Address : process.env.FINP2P_FA2_ADDRESS || 'KT1L2TH91yZ5hGquq28vud2N1eipQKRwiUqA',
   finp2pProxyAddress : process.env.FINP2P_PROXY_ADDRESS || 'KT1QfEsETrSaKvJTmrqFdLYAgRgq6Hw4hM8W',
 };

--- a/server/src/helpers/config.ts
+++ b/server/src/helpers/config.ts
@@ -190,7 +190,7 @@ export let accounts = (process.env.USE_FLEXTESA == 'true') ? Flextesa.accounts :
 // Initialize FinP2P library
 //TODO: move this to configuration
 export const contracts = {
-  finp2pAuthAddress : process.env.FINP2P_AUTH_ADDRESS || 'KT1B8ZhxLP6w6B2R5DtUs1KJbp6Gi9qn5Tyw',
-  finp2pFA2Address : process.env.FINP2P_FA2_ADDRESS || 'KT1L2TH91yZ5hGquq28vud2N1eipQKRwiUqA',
-  finp2pProxyAddress : process.env.FINP2P_PROXY_ADDRESS || 'KT1QfEsETrSaKvJTmrqFdLYAgRgq6Hw4hM8W',
+  finp2pAuthAddress : process.env.FINP2P_AUTH_ADDRESS || 'KT1QrFjiATDrTRAj6Y17K815GPDFWzhrGpjf',
+  finp2pFA2Address : process.env.FINP2P_FA2_ADDRESS || 'KT1L6ECRXS6j2gD4owz2eQAgC1tHdsU52qn4',
+  finp2pProxyAddress : process.env.FINP2P_PROXY_ADDRESS || 'KT1XdwJGUSMuVxRnZaqw2CQjs7ZSP1md4Zn7',
 };

--- a/tezos-lib/tests/redeploy_contracts.ts
+++ b/tezos-lib/tests/redeploy_contracts.ts
@@ -1,0 +1,54 @@
+import { InMemorySigner } from '@taquito/signer'
+import * as Finp2pProxy from '../finp2p_proxy'
+import { promisify } from "util";
+
+import * as fs from 'fs'
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+
+async function main (file : string) {
+
+  var fileContents = await readFile(file, 'utf8')
+  var testnetConfig = JSON.parse(fileContents)
+
+  const config =
+    testnetConfig as Finp2pProxy.Config & {
+      account : {pk : string; pkh : string; sk : string}
+      blockTime : number }
+
+  // Remove smart contracts from config to force redeployment
+  config.finp2pAuthAddress = undefined
+  config.finp2pFA2Address = undefined
+  config.finp2pProxyAddress = undefined
+
+  const FinP2PTezos = new Finp2pProxy.FinP2PTezos(config)
+  const signer = new InMemorySigner(config.account.sk)
+  FinP2PTezos.registerSigner(signer)
+  FinP2PTezos.taquito.setSignerProvider(signer)
+
+  console.log('Redeploying contracts')
+  await FinP2PTezos.init({
+    operationTTL : {
+      ttl : BigInt(15 * config.blockTime), // 15 blocks
+      allowed_in_the_future : BigInt(2 * config.blockTime) // 2 block
+    },
+    fa2Metadata : { name : "FinP2P FA2 assets",
+                    description : "FinP2P assets for ORG" }
+  })
+
+  // This is in case we want to redeploy and change the config
+  console.log('\nContracts redeployed')
+  console.log(`Auth  : ${FinP2PTezos.config.finp2pAuthAddress}`)
+  console.log(`FA2   : ${FinP2PTezos.config.finp2pFA2Address}`)
+  console.log(`Proxy : ${FinP2PTezos.config.finp2pProxyAddress}`)
+
+  console.log('\nWriting configuration file');
+  testnetConfig.finp2pAuthAddress = FinP2PTezos.config.finp2pAuthAddress;
+  testnetConfig.finp2pFA2Address = FinP2PTezos.config.finp2pFA2Address;
+  testnetConfig.finp2pProxyAddress = FinP2PTezos.config.finp2pProxyAddress;
+
+  await writeFile(file, JSON.stringify(testnetConfig, null, 2))
+  console.log(`File ${file} written`);
+}
+
+(async () => { (main (process.argv[2])).catch(console.error) })()

--- a/tezos-lib/tests/test_init.ts
+++ b/tezos-lib/tests/test_init.ts
@@ -32,7 +32,7 @@ export function run() {
   })
 
   it('Top up admin accounts to 10tz', async () => {
-    let op = await FinP2PTezos.topUpXTZ(FinP2PTezos.config.admins, 10, Net.account.pkh)
+    let op = await FinP2PTezos.topUpXTZ(FinP2PTezos.config.admins.concat([Net.other_account.pkh]), 10, Net.account.pkh)
     if (op !== undefined) {
       log("waiting inclusion")
       await FinP2PTezos.waitInclusion(op)

--- a/tezos-lib/tests/test_lib.ts
+++ b/tezos-lib/tests/test_lib.ts
@@ -251,23 +251,23 @@ module Flextesa {
 
   export const accounts = [account].concat(extra_accounts)
 
-  let flextesa_image = 'oxheadalpha/flextesa:20211221'
+  let flextesa_image = 'oxheadalpha/flextesa:latest'
   let flexteas_script : string
   switch (process.env.FINP2P_SANDBOX_NETWORK) {
-    case 'hangzhou':
-    case 'hangzbox':
-      flexteas_script = 'hangzbox'
-      break
     case 'ithaca':
     case 'ithacabox':
       flexteas_script = 'ithacabox'
+      break
+    case 'jakarta':
+    case 'jakartabox':
+      flexteas_script = 'jakartabox'
       break
     case 'alpha':
     case 'alphabox':
       flexteas_script = 'alphabox'
       break
     case undefined:
-      flexteas_script = 'hangzbox';
+      flexteas_script = 'ithacabox';
       break
     default:
       flexteas_script = process.env.FINP2P_SANDBOX_NETWORK

--- a/tezos-lib/tests/test_lib.ts
+++ b/tezos-lib/tests/test_lib.ts
@@ -15,6 +15,8 @@ import { OperationResult  } from '../taquito_wrapper';
 
 import * as testFa2Code from '../../dist/michelson/for_tests/test_fa2.json';
 
+import * as testnetConfig from '../../configs/testnet-config.json';
+
 const utf8 = new TextEncoder()
 
 let debug = false
@@ -195,16 +197,17 @@ const extra_accounts = [
   }
 ]
 
-module Hangzhounet {
+module Testnet {
+
+  export const config =
+    testnetConfig as
+      Finp2pProxy.Config &
+      {account : {pk : string; pkh : string; sk : string}}
 
   // This is the account that we will use to sign transactions on Tezos Note that
   // this account must also be an admin of the `finp2p_proxy` contract
   // Testnet faucet accounts can be obtained here: https://teztnets.xyz
-  export const account = {
-    pkh : "tz1ST4PBJJT1WqwGfAGkcS5w2zyBCmDGdDMz",
-    pk : "edpkuDn6QhAiGahpciQicYAgdjoXZTP1hqLRxs9ZN1bLSexJZ5tJVq",
-    sk : "edskRmhHemySiAV8gmhiV2UExyynQKv6tMAVgxur59J1ZFGr5dbu3SH2XU9s7ZkQE6NYFFjzNPyhuSxfrfgd476wcJo2Z9GsZS"
-  }
+  export const account = config.account
 
   export const other_account = {
     pkh : "tz1Uxpw1ojH9r2k48vfNiB7CTrPbniJgmeGG",
@@ -219,18 +222,9 @@ module Hangzhounet {
 
   export var block_time = 30
 
-  export const config: Finp2pProxy.Config = {
-    url : "https://rpc.hangzhounet.teztnets.xyz",
-    explorers : [
-      { kind : 'TzKT', url : 'https://api.hangzhou2net.tzkt.io' },
-      { kind : 'tzstats', url : 'https://api.hangzhou.tzstats.com' },
-    ],
-    admins : accounts.map(a => a.pkh),
-    finp2pAuthAddress : 'KT19FphHNf55Y5LkEQwXtBw9w2zJsiHNduj2',
-    finp2pFA2Address : 'KT1L2TH91yZ5hGquq28vud2N1eipQKRwiUqA',
-    finp2pProxyAddress : 'KT1QfEsETrSaKvJTmrqFdLYAgRgq6Hw4hM8W',
-    debug
-  }
+  config.admins = accounts.map(a => a.pkh)
+  config.debug = debug
+  config.explorers.map ((e : any) => e.kind = (e.kind as 'TzKT' | 'tzstats'));
 
   export const poll = undefined
 
@@ -335,8 +329,8 @@ module Flextesa {
 export var Net : typeof Flextesa
 
 switch (process.env.FINP2P_TEST_NETWORK) {
-  case 'hangzhounet':
-    Net = Hangzhounet
+  case 'testnet':
+    Net = Testnet
     break
   default:
     Net = Flextesa


### PR DESCRIPTION
To redeploy contracts, run:
```sh
script/redeploy.sh
````
It will use the account, node, etc. of the configuration stored in [configs/testnet-config.json](https://github.com/owneraio/finp2p-tezos-adapter/blob/script-redeploy/configs/testnet-config.json).